### PR TITLE
Updated plugin.xml to be valid xml

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -25,8 +25,8 @@
   <js-module src="www/com.salesforce.util.push.js" name="util.push"></js-module>
 
   <engines>
-    <engine name="cordova" version=">=3.5.0" />
-    <engine name="cordova" version="<=3.8.0" />
+    <engine name="cordova" version="&gt;=3.5.0" />
+    <engine name="cordova" version="&lt;=3.8.0" />
   </engines>
 
   <dependency id="org.apache.cordova.device"/>


### PR DESCRIPTION
Visual Studio 2015 has Cordova integration and supports installing plugins via git.  However it fails trying to parse the Salesforce Mobile SDK plugin.xml because the attributes contain greater than and less than symbols.  It works with the simple change included in this pull request.