### PR TITLE
Added NSAppTransportSecurity entries for IOS 9

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -45,6 +45,28 @@
       <feature name="com.salesforce.smartsync"><param name="ios-package" value="SFSmartSyncPlugin"/></feature>
     </config-file>
 
+    <config-file target="*-Info.plist" parent="NSAppTransportSecurity">
+      <dict>
+        <key>NSExceptionDomains</key>
+        <dict>
+          <key>salesforce.com</key>
+          <dict>
+            <key>NSIncludesSubdomains</key>
+            <true/>
+            <key>NSExceptionRequiresForwardSecrecy</key>
+            <false/>
+          </dict>
+          <key>force.com</key>
+          <dict>
+            <key>NSIncludesSubdomains</key>
+            <true/>
+            <key>NSExceptionRequiresForwardSecrecy</key>
+            <false/>
+          </dict>
+        </dict>
+      </dict>
+    </config-file>
+
     <!-- Header files -->
     <header-file src="src/ios/headers/SFAuthenticationManager.h" target-dir="salesforce"/>
     <header-file src="src/ios/headers/SFCommunityData.h" target-dir="salesforce" />


### PR DESCRIPTION
plugin.xml updated so that the required entries for IOS 9 are populated in the  <APP>-Info.plist file.

These changes are based upon this commit in the IOS repo - https://github.com/wmathurin/SalesforceMobileSDK-iOS/commit/6f9597a84f9e8b2564deba88479be1131148ac24

Relates to this G+ post https://plus.google.com/116610837536325321416/posts/beAoosuyd6i