### PR TITLE
Commenting out whitelist entries for iOS

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -39,14 +39,28 @@
       <preference name="BackupWebStorage" value="local" />
 
       <!-- To allow XHR requests with the new Whitelist plugin -->
+      <!--
+      FIXME:
+      Commenting whitelist entries until Mobile SDK plugin supports a version of Cordova with a functioning whitelist plugin.
+
       <allow-navigation href="https://localhost" />
       <allow-navigation href="https://*.force.com" />
       <allow-navigation href="https://*.salesforce.com" />
 
+      FIXME:
+      -->
+
       <!-- For legacy apps that don't use CSP -->
+      <!--
+      FIXME:
+      Commenting whitelist entries until Mobile SDK plugin supports a version of Cordova with a functioning whitelist plugin.
+
       <access origin="https://localhost" />
       <access origin="https://*.force.com" />
       <access origin="https://*.salesforce.com" />
+
+      FIXME:
+      -->
       <feature name="com.salesforce.oauth"><param name="ios-package" value="SalesforceOAuthPlugin"/></feature>
       <feature name="com.salesforce.sdkinfo"><param name="ios-package" value="SFSDKInfoPlugin"/></feature>
       <feature name="com.salesforce.sfaccountmanager"><param name="ios-package" value="SFAccountManagerPlugin"/></feature>


### PR DESCRIPTION
Cordova iOS versions earlier than 4.0 have a whitelisting issue, where the translation of whitelist config entries (e.g. `<access />` entries) into ATS configuration does not override the default behavior of allowing access to all hosts—it merely augments it with further restrictions to the access hosts specified.  This has the effect of breaking login to our configured salesforce endpoints, while not providing any whitelisting security.

This looks like it is / will be fixed in Cordova for iOS 4.0 ([CB-9569](https://issues.apache.org/jira/browse/CB-9569)).  I'm commenting our whitelisting entries out until we can support 4.0.  We do have the forward secrecy settings we specify in our plist configuration, so Salesforce endpoints will still get an elevated level of scrutiny as to their identity.  From the [whitelisting docs](https://cordova.apache.org/docs/en/5.4.0/guide/appdev/whitelist/index.html), it looks like we may be able to ditch our explicit plist configuration in plugin.xml, in favor of some additional attributes to the `<access />` tags, once we support 4.0.