### PR TITLE
Using specific versions of plugin dependencies

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -29,9 +29,10 @@
     <engine name="cordova-ios" version="3.9.2" />
   </engines>
 
-  <dependency id="cordova-plugin-whitelist" />
-  <dependency id="cordova-plugin-device" />
-  <dependency id="phonegap-plugin-push" />
+  <!-- Specific versions of dependencies required by the Mobile SDK plugin -->
+  <dependency id="cordova-plugin-whitelist" url="https://github.com/apache/cordova-plugin-whitelist" commit="1.2.0" />
+  <dependency id="cordova-plugin-device" url="https://github.com/apache/cordova-plugin-device" commit="r1.0.1" />
+  <dependency id="phonegap-plugin-push" url="https://github.com/phonegap/phonegap-plugin-push" commit="1.5.0" />
 
   <!-- ios -->
   <platform name="ios">


### PR DESCRIPTION
phonegap-push-plugin got a new version out (1.6.0) four days ago which requires cordova-ios 4.0.0.
As a result, our plugin can no longer be installed.