### PR TITLE
Fix for command line Gradle compilation

### DIFF
--- a/tools/postinstall-android.js
+++ b/tools/postinstall-android.js
@@ -97,7 +97,7 @@ if(data.indexOf("org.apache.http.legacy") < 0 && data.indexOf("allprojects") < 0
     var oldAndroidDepTree = "android {";
     var newAndroidDepTree = "android {\n\tpackagingOptions {\n\t\texclude 'META-INF/LICENSE'\n\t\texclude 'META-INF/LICENSE.txt'\n\t\texclude 'META-INF/DEPENDENCIES'\n\t\texclude 'META-INF/NOTICE'\n\t}";
     replaceTextInFile(path.join(appProjectRoot, 'build.gradle'), oldAndroidDepTree, newAndroidDepTree);
-    shelljs.echo("allprojects {\n\trepositories {\n\t\tmavenCentral\(\)\n\t}\n}").toEnd(path.join(appProjectRoot, 'build.gradle'));
+    shelljs.echo("allprojects {\n\trepositories {\n\t\tjcenter\(\)\n\t}\n}").toEnd(path.join(appProjectRoot, 'build.gradle'));
     var oldBuildScriptDepTree = "buildscript {";
     var newBuildScriptDepTree = "buildscript {\n\tdependencies {\n\t\tclasspath 'com.android.tools.build:gradle:2.2.2'\n\t}\n";
     replaceTextInFile(path.join(appProjectRoot, 'build.gradle'), oldBuildScriptDepTree, newBuildScriptDepTree);
@@ -107,6 +107,7 @@ if(data.indexOf("org.apache.http.legacy") < 0 && data.indexOf("allprojects") < 0
     replaceTextInFile(path.join(appProjectRoot, 'build.gradle'), oldAndroidDepTree, useLegacyStr);
     replaceTextInFile(path.join(appProjectRoot, 'build.gradle'), 'debugCompile project(path: \"CordovaLib\", configuration: \"debug\")', newLibDep);
     replaceTextInFile(path.join(appProjectRoot, 'build.gradle'), 'releaseCompile project(path: \"CordovaLib\", configuration: \"release\")', '');
+    replaceTextInFile(path.join(appProjectRoot, 'build.gradle'), 'mavenCentral', 'jcenter');
 }
 console.log("Done running SalesforceMobileSDK plugin android post-install script");
 


### PR DESCRIPTION
The issue was that the tool is published only to `jcenter`, not to `mavenCentral`.