### PR TITLE
Fixed registerPushNotificationHandler callback

### DIFF
--- a/www/com.salesforce.util.exec.js
+++ b/www/com.salesforce.util.exec.js
@@ -37,9 +37,9 @@ var exec = function(pluginVersion, successCB, errorCB, service, action, args) {
             if (typeof successCB === "function")
                 successCB.apply(null, arguments);
         },
-        function() {
+        function(error) {
             console.timeEnd(tag);
-            console.error(tag + " failed");
+            console.error(tag + " failed - Error: " + error);
             if (typeof errorCB === "function")
                 errorCB.apply(null, arguments);
         },

--- a/www/com.salesforce.util.push.js
+++ b/www/com.salesforce.util.push.js
@@ -56,9 +56,7 @@ var registerPushNotificationHandler = function(notificationHandler, fail) {
         push.on('notification', function(data) {
           console.log("notification event");
           console.log(JSON.stringify(data));
-          if (data.event == "message") {
-            notificationHandler(message);
-          }
+          notificationHandler(message);
           push.finish(function () {
               console.log('finish successfully called');
           });

--- a/www/com.salesforce.util.push.js
+++ b/www/com.salesforce.util.push.js
@@ -56,7 +56,7 @@ var registerPushNotificationHandler = function(notificationHandler, fail) {
         push.on('notification', function(data) {
           console.log("notification event");
           console.log(JSON.stringify(data));
-          notificationHandler(message);
+          notificationHandler(data);
           push.finish(function () {
               console.log('finish successfully called');
           });


### PR DESCRIPTION
This callback will never be called. There does not appear to be a "data.event" thrown by the PhoneGap Push plugin. There are also several unresolved support threads related to this:

https://developer.salesforce.com/forums/?id=9060G000000Xa5SQAS
https://github.com/forcedotcom/SalesforceMobileSDK-CordovaPlugin/issues/297