### PR TITLE
use defined error variable in push notification handler

### DIFF
--- a/www/com.salesforce.util.push.js
+++ b/www/com.salesforce.util.push.js
@@ -67,7 +67,7 @@ var registerPushNotificationHandler = function(notificationHandler, fail) {
         push.on('error', function(e) {
             console.log("push error");
             console.error("push error " + JSON.stringify(e));
-            fail(err);
+            fail(e);
         });
     });
 };


### PR DESCRIPTION
push error handler uses an undefined variable