### PR TITLE
Fixing SQLite issue

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -37,7 +37,7 @@
   <!-- Specific versions of dependencies required by the Mobile SDK plugin -->
   <dependency id="cordova-plugin-whitelist" version="1.2.0" />
   <dependency id="cordova-plugin-device" version="1.0.1" />
-  <dependency id="phonegap-plugin-push" version="1.5.1" />
+  <dependency id="phonegap-plugin-push" version="1.4.5" />
 
   <!-- ios -->
   <platform name="ios">


### PR DESCRIPTION
The newer version of push plugin was pulling in `SQLite` that was forcing `SmartStore` to use `SQLite` instead of `SQLCipher`, due to late binding. This downgrades the plugin to a version that doesn't use `SQLite` to avoid this issue.