### PR TITLE
Removing forced dependency on phonegap-plugin-push

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -36,7 +36,7 @@
 
   <!-- Specific versions of dependencies required by the Mobile SDK plugin -->
   <dependency id="cordova-plugin-whitelist" version="1.2.0" />
-  <dependency id="phonegap-plugin-push" version="2.2.3" />
+  <dependency id="phonegap-plugin-push" version="2.1.2" />
 
   <!-- ios -->
   <platform name="ios">

--- a/plugin.xml
+++ b/plugin.xml
@@ -36,7 +36,6 @@
 
   <!-- Specific versions of dependencies required by the Mobile SDK plugin -->
   <dependency id="cordova-plugin-whitelist" version="1.2.0" />
-  <dependency id="phonegap-plugin-push" version="2.1.2" />
 
   <!-- ios -->
   <platform name="ios">

--- a/plugin.xml
+++ b/plugin.xml
@@ -8,7 +8,7 @@
   <name>SalesforceMobileSDK Plugins</name>
   <description>SalesforceMobileSDK Plugins</description>
   <license>Apache 2.0</license>
-  <keywords>salesforce,oauth,smartstore</keywords>
+  <keywords>salesforce,oauth,smartstore,smartsync</keywords>
   <repo>https://github.com/forcedotcom/SalesforceMobileSDK-CordovaPlugin</repo>
 
   <js-module src="www/com.salesforce.plugin.oauth.js" name="plugin.oauth"></js-module>
@@ -36,13 +36,13 @@
 
   <!-- Specific versions of dependencies required by the Mobile SDK plugin -->
   <dependency id="cordova-plugin-whitelist" version="1.2.0" />
-  <dependency id="phonegap-plugin-push" version="1.4.5" />
+  <dependency id="phonegap-plugin-push" version="2.2.3" />
 
   <!-- ios -->
   <platform name="ios">
 
-  <!-- Required by the Mobile SDK plugin for WKWebView -->
-  <dependency id="cordova-plugin-wkwebview-engine" url="https://github.com/apache/cordova-plugin-wkwebview-engine" commit="1.1.2" />
+    <!-- Required by the Mobile SDK plugin for WKWebView -->
+    <dependency id="cordova-plugin-wkwebview-engine" url="https://github.com/apache/cordova-plugin-wkwebview-engine" commit="1.1.2" />
 
     <config-file target="config.xml" parent="/*">
       <preference name="BackupWebStorage" value="local" />

--- a/www/com.salesforce.util.push.js
+++ b/www/com.salesforce.util.push.js
@@ -24,11 +24,11 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-// Version this js was shipped with
+// Version this js was shipped with.
 var SALESFORCE_MOBILE_SDK_VERSION = "7.0.0";
 
 /**
- * Register push notification handler
+ * Register push notification handler.
  */
 var registerPushNotificationHandler = function(notificationHandler, fail) {
     if (!window.PushNotification) {
@@ -36,42 +36,40 @@ var registerPushNotificationHandler = function(notificationHandler, fail) {
         fail("PushPlugin not found");
         return;
     }
-
     cordova.require("com.salesforce.plugin.sdkinfo").getInfo(function(info) {
         var bootconfig = info.bootConfig;
-
         var push = PushNotification.init({
-                "android": {
-                    "senderID": bootconfig.androidPushNotificationClientId
-                },
-                "ios": {"alert": "true", "badge": "true", "sound": "true"},
-                "windows": {}
-            });
-
+            "android": {
+                "senderID": bootconfig.androidPushNotificationClientId
+            },
+            "ios": {
+                "alert": "true",
+                "badge": "true",
+                "sound": "true"
+            }
+        });
         push.on('registration', function(data) {
-            console.log("registration event " + JSON.stringify(data));
+            console.log("Registration event " + JSON.stringify(data));
             console.log(JSON.stringify(data));
         });
-
         push.on('notification', function(data) {
-          console.log("notification event");
+          console.log("Notification event");
           console.log(JSON.stringify(data));
           notificationHandler(data);
           push.finish(function () {
-              console.log('finish successfully called');
+              console.log('Finish successfully called');
           });
         });
-
         push.on('error', function(e) {
-            console.log("push error");
-            console.error("push error " + JSON.stringify(e));
+            console.log("Push error");
+            console.error("Push error " + JSON.stringify(e));
             fail(e);
         });
     });
 };
 
 /**
- * Part of the module that is public
+ * Part of the module that is public.
  */
 module.exports = {
     registerPushNotificationHandler: registerPushNotificationHandler

--- a/www/com.salesforce.util.push.js
+++ b/www/com.salesforce.util.push.js
@@ -24,7 +24,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-// Version this js was shipped with.
+// Version this js was shipped with
 var SALESFORCE_MOBILE_SDK_VERSION = "7.0.0";
 
 /**
@@ -53,12 +53,12 @@ var registerPushNotificationHandler = function(notificationHandler, fail) {
             console.log(JSON.stringify(data));
         });
         push.on('notification', function(data) {
-          console.log("Notification event");
-          console.log(JSON.stringify(data));
-          notificationHandler(data);
-          push.finish(function () {
-              console.log('Finish successfully called');
-          });
+            console.log("Notification event");
+            console.log(JSON.stringify(data));
+            notificationHandler(data);
+            push.finish(function () {
+                console.log('Finish successfully called');
+            });
         });
         push.on('error', function(e) {
             console.log("Push error");

--- a/www/com.salesforce.util.push.js
+++ b/www/com.salesforce.util.push.js
@@ -32,8 +32,8 @@ var SALESFORCE_MOBILE_SDK_VERSION = "7.0.0";
  */
 var registerPushNotificationHandler = function(notificationHandler, fail) {
     if (!window.PushNotification) {
-        console.error("PushPlugin not found");
-        fail("PushPlugin not found");
+        console.error("PushPlugin not found. Please install the plugin from https://github.com/phonegap/phonegap-plugin-push.");
+        fail("PushPlugin not found. Please install the plugin from https://github.com/phonegap/phonegap-plugin-push.");
         return;
     }
     cordova.require("com.salesforce.plugin.sdkinfo").getInfo(function(info) {


### PR DESCRIPTION
<b>I removed the dependency on `phonegap-plugin-push` for the following reasons:</b>
- It has many other dependencies, including a bunch of `Firebase` dependencies that slow down the project and are unnecessary for projects that don't use push notifications.
- Even for those projects that use push notifications, the registration piece (to FCM/APNS and SFDC) is handled by the native portions of `Mobile SDK` at the end of the login flow, so this plugin does NOT add value there.
- The only use case where the plugin adds value is to receive the incoming notification in JS and pass display it for hybrid `WebView` based apps.
- The plugin itself is designed to be included at the app level, with app-specific settings. We were working around it with earlier versions of the plugin, but can't anymore with the upgrade to FCM. The new version of the plugin requires a file generated by `Firebase` called `google-services.json`. This is app-specific and we can't work around this.
- By depending on this plugin, we subject apps that do not use push notifications to the above requirement, which IMO is unreasonable.

Given the above reasons, it's best that we don't require this plugin. Apps that want to receive notifications in JS land can easily add the plugin themselves using a one-liner and can add their own `google-services.json`.