### PR TITLE
Correct the newMode when fingerprint is not available

### DIFF
--- a/src/android/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/PasscodeActivity.java
+++ b/src/android/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/PasscodeActivity.java
@@ -294,6 +294,7 @@ public class PasscodeActivity extends Activity {
                 launchBiometricAuth();
             } else {
                 setMode(PasscodeMode.Check);
+                newMode = PasscodeMode.Check;
             }
             break;
         }


### PR DESCRIPTION
This is related to issue as reported at
https://github.com/forcedotcom/SalesforceMobileSDK-CordovaPlugin/issues/474

When fingerprint fails, then setMode(PasscodeMode.Check) will be executed for the second time. This code will set the currentMode variable to 'PasscodeMode.Check'. However, when it finishes it will return to the initial setMode block and set the currentMode back to 'PasscodeMode.BiometricCheck'. When I enter the passcode in the UI, it will trigger the onSubmit method. The onSubmit method has a switch statement that does not recognises 'PasscodeMode.BiometricCheck' and onSubmit is not processed..
