### PR TITLE
Stop refresh on activity resize

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -145,7 +145,7 @@
 
     <!-- Fixes the activity tag in the Manifest -->
     <edit-config file="app/src/main/AndroidManifest.xml" target="/manifest/application/activity" mode="merge">
-      <activity android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale"
+      <activity android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|smallestScreenSize|screenLayout|uiMode"
           android:label="@string/app_name"
           android:name="com.salesforce.androidsdk.phonegap.ui.SalesforceDroidGapActivity"
           android:theme="@android:style/Theme.Black.NoTitleBar"


### PR DESCRIPTION
Whenever app is used in split-screen or connected to car dock, the webview refreshes as activity is resized. 
The new attributes added to `configChanges` will prevent the activity from being restarted.

More details about the attributes - [here](https://developer.android.com/guide/topics/manifest/activity-element#config)