### PR TITLE
redirect file:///android_asset/www call to http(s)://localhost

### DIFF
--- a/src/android/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/ui/SalesforceDroidGapActivity.java
+++ b/src/android/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/ui/SalesforceDroidGapActivity.java
@@ -80,6 +80,9 @@ public class SalesforceDroidGapActivity extends CordovaActivity implements Sales
     // Web app loaded?
     private boolean webAppLoaded = false;
 
+    // Base url:http(s)://localhost by default
+    private String baseUrl;
+
     public SalesforceDroidGapActivity() {
         super();
         delegate = new SalesforceActivityDelegate(this);
@@ -92,6 +95,9 @@ public class SalesforceDroidGapActivity extends CordovaActivity implements Sales
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         init();
+
+        // Init base url
+        initBaseUrl();
 
         // Get bootconfig
         bootconfig = BootConfig.getBootConfig(this);
@@ -580,4 +586,27 @@ public class SalesforceDroidGapActivity extends CordovaActivity implements Sales
             return null;
         }
     }
+
+    /**
+     * Init base url from scheme and hostname preferences 
+    **/
+    private initBaseUrl() {
+        String scheme = preferences.getString("scheme", "http");
+        String hostname = preferences.getString("hostname", "localhost");
+        baseUrl = scheme + "://" + hostname; 
+    }
+
+   /**
+    * Customize loadUrl method
+    * Replace asset base url by http(s)://localhost to comply with new cordova android assets load mechanism
+   **/
+  @Override
+  public void loadUrl(String url) {
+    String rightUrl = url;
+    String oldBaseUrl = "file:///android_asset/www";
+    if (url.startsWith(oldBaseUrl)) {
+        rightUrl = url.replaceFirst(oldBaseUrl, baseUrl);
+    }
+    super.loadUrl(rightUrl);
+  }
 }


### PR DESCRIPTION
As assets are served from https://localhost for Android (cordova-android v10.x.x), directly calling file:///android_asset/www + / + filename generates cors issue when other assets are loaded after the webview rendered the main page (index.html). These are little modifications on the SalesforceDroidGapActivity.java file which mainly redirect all url load from file:///android_asset/www to http(s)/localhost