### PR TITLE
@W-13557285: [Android] Upgrade to Gradle 8.x and AGP 8.x

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-cdvCompileSdkVersion=33
+cdvCompileSdkVersion=34
 cdvMinSdkVersion=24
 android.useAndroidX=true
 android.defaults.buildfeatures.buildconfig=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/plugin.xml
+++ b/plugin.xml
@@ -166,7 +166,7 @@
 
       <!-- To specify gradle and gradle plugin versions -->
       <preference name="GradleVersion" value="8.2.0" />
-µπ      <preference name="AndroidGradlePluginVersion" value="8.2.0"/>
+      <preference name="AndroidGradlePluginVersion" value="8.2.0"/>
       <preference name="GradlePluginKotlinEnabled" value="true" />
       <preference name="GradlePluginKotlinVersion" value="1.7.21" />
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -166,8 +166,9 @@
 
       <!-- To specify gradle and gradle plugin versions -->
       <preference name="GradleVersion" value="8.2.0" />
+µπ      <preference name="AndroidGradlePluginVersion" value="8.2.0"/>
       <preference name="GradlePluginKotlinEnabled" value="true" />
-      <preference name="GradlePluginKotlinVersion" value="1.9.20" />
+      <preference name="GradlePluginKotlinVersion" value="1.7.21" />
 
       <!-- To allow XHR requests with the new Whitelist plugin -->
       <allow-navigation href="https://localhost" />
@@ -194,7 +195,7 @@
 
       <!-- Kotlin in Plugin -->
       <preference name="GradlePluginKotlinEnabled" value="true" />
-      <preference name="GradlePluginKotlinVersion" value="1.9.20" />
+      <preference name="GradlePluginKotlinVersion" value="1.7.21" />
     </config-file>
 
     <config-file target="res/values/strings.xml" parent="/resources">

--- a/plugin.xml
+++ b/plugin.xml
@@ -124,7 +124,7 @@
     <framework src="AssetsLibrary.framework" weak="true" />
     <framework src="ImageIO.framework" weak="true" />
 
-    <!-- Post install script -->    
+    <!-- Post install script -->
     <hook type="after_plugin_install" src="tools/postinstall-ios.js" />
   </platform>
 
@@ -138,7 +138,7 @@
           android:name="com.salesforce.androidsdk.phonegap.ui.SalesforceDroidGapActivity"
           android:theme="@style/SalesforceSDK_SplashScreen"
           android:windowSoftInputMode="adjustResize"
-          android:launchMode="singleTop" 
+          android:launchMode="singleTop"
           android:allowBackup="false"
           android:exported="true"/>
     </edit-config>
@@ -162,10 +162,10 @@
 
       <!-- To specify min and target SDK versions -->
       <preference name="android-minSdkVersion" value="24" />
-      <preference name="android-targetSdkVersion" value="33" />
+      <preference name="android-targetSdkVersion" value="34" />
 
       <!-- To specify gradle and gradle plugin versions -->
-      <preference name="GradleVersion" value="7.4.2" />
+      <preference name="GradleVersion" value="8.2.0" />
       <preference name="GradlePluginKotlinEnabled" value="true" />
       <preference name="GradlePluginKotlinVersion" value="1.7.21" />
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -167,7 +167,7 @@
       <!-- To specify gradle and gradle plugin versions -->
       <preference name="GradleVersion" value="8.2.0" />
       <preference name="GradlePluginKotlinEnabled" value="true" />
-      <preference name="GradlePluginKotlinVersion" value="1.7.21" />
+      <preference name="GradlePluginKotlinVersion" value="1.9.20" />
 
       <!-- To allow XHR requests with the new Whitelist plugin -->
       <allow-navigation href="https://localhost" />
@@ -194,7 +194,7 @@
 
       <!-- Kotlin in Plugin -->
       <preference name="GradlePluginKotlinEnabled" value="true" />
-      <preference name="GradlePluginKotlinVersion" value="1.7.21" />
+      <preference name="GradlePluginKotlinVersion" value="1.9.20" />
     </config-file>
 
     <config-file target="res/values/strings.xml" parent="/resources">

--- a/src/android/libs/mobile_sdk/gradle/wrapper/gradle-wrapper.properties
+++ b/src/android/libs/mobile_sdk/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/android/libs/mobile_sdk/libs/SalesforceHybrid/res/xml/config.xml
+++ b/src/android/libs/mobile_sdk/libs/SalesforceHybrid/res/xml/config.xml
@@ -25,7 +25,7 @@
     <preference name="classicRender" value="true" />
     <preference name="AndroidXEnabled" value="true" />
     <preference name="AndroidInsecureFileModeEnabled" value="true" />
-    
+
     <feature name="App"><param name="android-package" value="org.apache.cordova.App"/></feature>
     <feature name="com.salesforce.oauth"><param name="android-package" value="com.salesforce.androidsdk.phonegap.plugin.SalesforceOAuthPlugin"/></feature>
     <feature name="com.salesforce.sfaccountmanager"><param name="android-package" value="com.salesforce.androidsdk.phonegap.plugin.SFAccountManagerPlugin"/></feature>


### PR DESCRIPTION
🎸 _**Ready For Final Review!**_ 🥁

  Be aware this pull request is one of four related to the React Native 0.72.7, Gradle 8.2 and Android Gradle Plugin 8.2.0 upgrades.
👉🏻 https://github.com/forcedotcom/SalesforceMobileSDK-Android/pull/2492
👉🏻 https://github.com/forcedotcom/SalesforceMobileSDK-CordovaPlugin/pull/631
👉🏻 https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative/pull/345
👉🏻 https://github.com/forcedotcom/SalesforceMobileSDK-Templates/pull/387

  This prepares SalesforceMobileSDK-CordovaPlugin for supporting React Native 0.72.7, Gradle 8, Android Gradle Plugin 8.2.0 and Android 34 in the other three repositories listed above.  Overall, the changes here are relatively small though the platform update has significant impacts to downstream projects.

  I tested this primarily by using `forcehybird` to generate every hybrid template I could conceive of.  Everything compiled and ran OK for both Android and iOS.