### PR TITLE
Fixing iOS hybrid app not compiling with SQLCipher 4.5.7

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -97,8 +97,7 @@
            <pod name="SalesforceHybridSDK" git="https://github.com/forcedotcom/SalesforceMobileSDK-iOS-Hybrid" branch="dev" />
            <pod name="MobileSync" git="https://github.com/forcedotcom/SalesforceMobileSDK-iOS" branch="dev" />
            <pod name="SmartStore" git="https://github.com/forcedotcom/SalesforceMobileSDK-iOS" branch="dev" />
-           <pod name="FMDB/SQLCipher" git="https://github.com/ccgus/fmdb" tag="2.7.10" />
-           <pod name="SQLCipher" git="https://github.com/sqlcipher/sqlcipher" tag="v4.5.7" />
+           <pod name="FMDB" git="https://github.com/ccgus/fmdb" tag="2.7.10" />
            <pod name="SalesforceSDKCore" git="https://github.com/forcedotcom/SalesforceMobileSDK-iOS" branch="dev" />
            <pod name="SalesforceAnalytics" git="https://github.com/forcedotcom/SalesforceMobileSDK-iOS" branch="dev" />
            <pod name="SalesforceSDKCommon" git="https://github.com/forcedotcom/SalesforceMobileSDK-iOS" branch="dev" />


### PR DESCRIPTION
The change to SQLCipher's podspec in 4.5.7 broke the build because we had two SQLCipher transitive dependencies.

https://github.com/sqlcipher/sqlcipher/commit/832e65896006e87719c1f6498b8f431df2d602b1