### PR TITLE
Bump Android minSdk to 31

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,8 +181,8 @@ Maps JavaScript files to Cordova namespaces:
 ```xml
 <platform name="android">
   <!-- Gradle and SDK versions -->
-  <preference name="android-minSdkVersion" value="28" />
-  <preference name="android-targetSdkVersion" value="35" />
+  <preference name="android-minSdkVersion" value="31" />
+  <preference name="android-targetSdkVersion" value="36" />
   <preference name="GradleVersion" value="8.14.3" />
   <preference name="AndroidGradlePluginVersion" value="8.12.0"/>
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 cdvCompileSdkVersion=35
-cdvMinSdkVersion=28
+cdvMinSdkVersion=31
 android.useAndroidX=true
 android.nonTransitiveRClass=true
 android.nonFinalResIds=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-cdvCompileSdkVersion=35
+cdvCompileSdkVersion=36
 cdvMinSdkVersion=31
 android.useAndroidX=true
 android.nonTransitiveRClass=true

--- a/plugin.xml
+++ b/plugin.xml
@@ -160,7 +160,7 @@
       <preference name="AndroidInsecureFileModeEnabled" value="true" />
 
       <!-- To specify min and target SDK versions -->
-      <preference name="android-minSdkVersion" value="28" />
+      <preference name="android-minSdkVersion" value="31" />
       <preference name="android-targetSdkVersion" value="36" />
 
       <!-- To specify gradle and gradle plugin versions -->

--- a/src/android/libs/mobile_sdk/CLAUDE.md
+++ b/src/android/libs/mobile_sdk/CLAUDE.md
@@ -42,8 +42,8 @@ SalesforceReact
 - [Android Javadoc](https://forcedotcom.github.io/SalesforceMobileSDK-Android/index.html)
 
 ### Android Build Details
-- **Minimum SDK**: 28 (Android 9.0)
-- **Compile SDK**: 35 (Android 15.0)
+- **Minimum SDK**: 31 (Android 12)
+- **Compile SDK**: 36 (Android 16)
 - **Target SDK**: Follows compileSdk
 - **Build system**: Gradle 8.14.3 with Kotlin DSL (`.gradle.kts` files)
 - **AGP (Android Gradle Plugin)**: 8.12.0

--- a/src/android/libs/mobile_sdk/gradle.properties
+++ b/src/android/libs/mobile_sdk/gradle.properties
@@ -1,5 +1,5 @@
 cdvCompileSdkVersion=35
-cdvMinSdkVersion=28
+cdvMinSdkVersion=31
 android.useAndroidX=true
 android.nonTransitiveRClass=true
 android.nonFinalResIds=false

--- a/src/android/libs/mobile_sdk/gradle.properties
+++ b/src/android/libs/mobile_sdk/gradle.properties
@@ -1,4 +1,4 @@
-cdvCompileSdkVersion=35
+cdvCompileSdkVersion=36
 cdvMinSdkVersion=31
 android.useAndroidX=true
 android.nonTransitiveRClass=true

--- a/src/android/libs/mobile_sdk/libs/MobileSync/build.gradle.kts
+++ b/src/android/libs/mobile_sdk/libs/MobileSync/build.gradle.kts
@@ -28,7 +28,7 @@ android { // TODO: This cannot be resolved until newDSL=true
     compileSdk = 36 // TODO: MSDK 14 will remain on 36.  The next increment will be in MSDK 15.
 
     defaultConfig {
-        minSdk = 28
+        minSdk = 31
         consumerProguardFiles("consumer-rules.pro")
     }
 

--- a/src/android/libs/mobile_sdk/libs/SalesforceAnalytics/build.gradle.kts
+++ b/src/android/libs/mobile_sdk/libs/SalesforceAnalytics/build.gradle.kts
@@ -27,7 +27,7 @@ android { // TODO: This cannot be resolved until newDSL=true
     compileSdk = 36 // TODO: MSDK 14 will remain on 36.  The next increment will be in MSDK 15.
 
     defaultConfig {
-        minSdk = 28
+        minSdk = 31
     }
 
     buildTypes {

--- a/src/android/libs/mobile_sdk/libs/SalesforceHybrid/build.gradle.kts
+++ b/src/android/libs/mobile_sdk/libs/SalesforceHybrid/build.gradle.kts
@@ -33,7 +33,7 @@ android { // TODO: This cannot be resolved until newDSL=true
     compileSdk = 36 // TODO: MSDK 14 will remain on 36.  The next increment will be in MSDK 15.
 
     defaultConfig {
-        minSdk = 28
+        minSdk = 31
     }
 
     buildTypes {

--- a/src/android/libs/mobile_sdk/libs/SalesforceSDK/build.gradle.kts
+++ b/src/android/libs/mobile_sdk/libs/SalesforceSDK/build.gradle.kts
@@ -65,7 +65,7 @@ android { // TODO: This cannot be resolved until newDSL=true
     compileSdk = 36 // TODO: MSDK 14 will remain on 36.  The next increment will be in MSDK 15.
 
     defaultConfig {
-        minSdk = 28
+        minSdk = 31
         consumerProguardFiles("consumer-rules.pro")
     }
 

--- a/src/android/libs/mobile_sdk/libs/SmartStore/build.gradle.kts
+++ b/src/android/libs/mobile_sdk/libs/SmartStore/build.gradle.kts
@@ -31,7 +31,7 @@ android { // TODO: This cannot be resolved until newDSL=true
     compileSdk = 36 // TODO: MSDK 14 will remain on 36.  The next increment will be in MSDK 15.
 
     defaultConfig {
-        minSdk = 28
+        minSdk = 31
         consumerProguardFiles("consumer-rules.pro")
     }
 


### PR DESCRIPTION
## Summary
- Bumps `android-minSdkVersion` from 28 to 31 in `plugin.xml` and `gradle.properties`.
- Updates the snapshotted Android SDK libs under `src/android/libs/mobile_sdk/` (will be regenerated by `tools/update.sh` at next release).

## Test plan
- [ ] Generate a hybrid app from a template and verify it builds against minSdk 31
- [ ] Verify `tools/update.sh` regeneration produces the same minSdk values

🤖 Generated with [Claude Code](https://claude.com/claude-code)