### PR TITLE
W-19008525: Remove adjustResize from SalesforceDroidGapActivity

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -139,7 +139,6 @@
           android:label="@string/app_name"
           android:name="com.salesforce.androidsdk.phonegap.ui.SalesforceDroidGapActivity"
           android:theme="@style/SalesforceSDK_SplashScreen"
-          android:windowSoftInputMode="adjustResize"
           android:launchMode="singleTop"
           android:allowBackup="false"
           android:exported="true"/>


### PR DESCRIPTION
## Summary

Remove `android:windowSoftInputMode="adjustResize"` from `SalesforceDroidGapActivity` in `plugin.xml`.

`adjustResize` is deprecated on Android API 35+ in edge-to-edge windows and has no effect on API 36 / Android 16. Cordova 15 now handles inset management via `OnApplyWindowInsetsListener`.

## Edge-to-edge context

The original goal of W-19008525 is effectively achieved by Cordova 15 itself, without any MSDK-level intervention. Cordova 15 unconditionally calls `WindowCompat.setDecorFitsSystemWindows(window, false)` (entering edge-to-edge mode at the window level), then applies compensating inset margins to the WebView via `OnApplyWindowInsetsListener` — pushing content away from system bars and recreating the appearance of the old non-edge-to-edge layout. This happens regardless of the `AndroidEdgeToEdge` preference.

The `adjustResize` removal here is still correct (the attribute is deprecated and ineffective on API 35+), but the core concern — hybrid WebView content underlapping system bars — was already handled by the Cordova 15 upgrade. No additional MSDK code was needed.

## GUS

W-19008525

## Test plan

- [ ] Generate a hybrid app with `forcehybrid` and verify keyboard behavior in a text input field
- [ ] Verify no regression on earlier Android API levels (31-34)