### PR TITLE
W-19408803: Inject MainApplication.kt into generated hybrid Android apps

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -146,12 +146,13 @@
     </edit-config>
 
     <!-- Fixes the application tag in the Manifest -->
+    <!-- android:name is intentionally omitted here — postinstall-android.js injects MainApplication.kt
+         and sets android:name to the app's own class (e.g. com.myapp.MainApplication) -->
     <edit-config file="app/src/main/AndroidManifest.xml" target="/manifest/application" mode="merge">
       <application android:hardwareAccelerated="true"
           android:icon="@drawable/sf__icon"
           android:label="@string/app_name"
-          android:manageSpaceActivity="com.salesforce.androidsdk.ui.ManageSpaceActivity"
-          android:name="com.salesforce.androidsdk.phonegap.app.HybridApp" />
+          android:manageSpaceActivity="com.salesforce.androidsdk.ui.ManageSpaceActivity" />
     </edit-config>
 
     <config-file target="res/xml/config.xml" parent="/*">

--- a/src/android/MainApplication.kt
+++ b/src/android/MainApplication.kt
@@ -21,6 +21,7 @@
 package com.salesforce.androidsdk.phonegap.app
 
 import android.app.Application
+import com.salesforce.androidsdk.phonegap.app.SalesforceHybridSDKManager
 
 /**
  * Application class for hybrid apps.

--- a/src/android/MainApplication.kt
+++ b/src/android/MainApplication.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026-present, salesforce.com, inc.
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ * - Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ *   following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *   the following disclaimer in the documentation and/or other materials provided with the distribution.
+ * - Neither the name of salesforce.com, inc. nor the names of its contributors may be used to endorse or
+ *   promote products derived from this software without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package __PACKAGE_NAME__
+
+import android.app.Application
+import com.salesforce.androidsdk.phonegap.app.SalesforceHybridSDKManager
+
+/**
+ * Application class for the hybrid app.
+ * Customize SDK initialization here.
+ */
+class MainApplication : Application() {
+
+    override fun onCreate() {
+        super.onCreate()
+        SalesforceHybridSDKManager.initHybrid(applicationContext)
+
+        /*
+         * Uncomment the following line to enable IDP login flow. This will allow the user to
+         * either authenticate using the current app or use the designated IDP app for login.
+         * Replace 'com.salesforce.samples.salesforceandroididptemplateapp' with the package name
+         * of the IDP app meant to be used.
+         */
+        // SalesforceHybridSDKManager.getInstance().idpAppPackageName = "com.salesforce.samples.salesforceandroididptemplateapp"
+
+        /*
+         * Uncomment the following line to enable push notifications in this app.
+         * Replace 'pnInterface' with your implementation of 'PushNotificationInterface'.
+         * Add your Firebase 'google-services.json' file to the 'app' folder of your project.
+         */
+        // SalesforceHybridSDKManager.getInstance().pushNotificationReceiver = pnInterface
+    }
+}

--- a/src/android/MainApplication.kt
+++ b/src/android/MainApplication.kt
@@ -18,13 +18,12 @@
  * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package __PACKAGE_NAME__
+package com.salesforce.androidsdk.phonegap.app
 
 import android.app.Application
-import com.salesforce.androidsdk.phonegap.app.SalesforceHybridSDKManager
 
 /**
- * Application class for the hybrid app.
+ * Application class for hybrid apps.
  * Customize SDK initialization here.
  */
 class MainApplication : Application() {

--- a/tools/postinstall-android.js
+++ b/tools/postinstall-android.js
@@ -87,7 +87,7 @@ if (packageMatch) {
     const mainAppSrc = path.join(pluginRoot, 'src', 'android', 'MainApplication.kt');
     const mainAppDest = path.join(mainAppSrcDir, 'MainApplication.kt');
     shelljs.cp(mainAppSrc, mainAppDest);
-    replaceTextInFile(mainAppDest, '__PACKAGE_NAME__', packageName);
+    replaceTextInFile(mainAppDest, 'com.salesforce.androidsdk.phonegap.app', packageName);
 
     // Set android:name in AndroidManifest.xml to point to the app's MainApplication.
     // plugin.xml no longer sets android:name, so we inject it here into the <application> tag.

--- a/tools/postinstall-android.js
+++ b/tools/postinstall-android.js
@@ -74,4 +74,27 @@ if (data.indexOf("SalesforceHybrid") < 0)
     replaceTextInFile(path.join(appProjectRoot, 'app', 'build.gradle'), 'implementation(project(path: \":CordovaLib\"))', newLibDep);
 }
 
+console.log('Injecting MainApplication.kt into generated app');
+const buildGradle = fs.readFileSync(path.join(appProjectRoot, 'app', 'build.gradle'), 'utf8');
+const packageMatch = buildGradle.match(/applicationId\s+["']([^"']+)["']/);
+if (packageMatch) {
+    const packageName = packageMatch[1];
+    const packagePath = packageName.replace(/\./g, path.sep);
+    const mainAppSrcDir = path.join(appProjectRoot, 'app', 'src', 'main', 'java', packagePath);
+    shelljs.mkdir('-p', mainAppSrcDir);
+    const mainAppSrc = path.join(pluginRoot, 'src', 'android', 'MainApplication.kt');
+    const mainAppDest = path.join(mainAppSrcDir, 'MainApplication.kt');
+    shelljs.cp(mainAppSrc, mainAppDest);
+    replaceTextInFile(mainAppDest, '__PACKAGE_NAME__', packageName);
+
+    // Fix android:name in AndroidManifest.xml to point to app's MainApplication
+    const manifestFile = path.join(appProjectRoot, 'app', 'src', 'main', 'AndroidManifest.xml');
+    replaceTextInFile(manifestFile,
+        'android:name="com.salesforce.androidsdk.phonegap.app.HybridApp"',
+        `android:name="${packageName}.MainApplication"`);
+    console.log(`MainApplication.kt injected at ${mainAppDest}`);
+} else {
+    console.warn('WARNING: Could not determine applicationId from app/build.gradle — MainApplication.kt not injected');
+}
+
 console.log("Done running SalesforceMobileSDK plugin android post-install script");

--- a/tools/postinstall-android.js
+++ b/tools/postinstall-android.js
@@ -89,11 +89,12 @@ if (packageMatch) {
     shelljs.cp(mainAppSrc, mainAppDest);
     replaceTextInFile(mainAppDest, '__PACKAGE_NAME__', packageName);
 
-    // Fix android:name in AndroidManifest.xml to point to app's MainApplication
+    // Set android:name in AndroidManifest.xml to point to the app's MainApplication.
+    // plugin.xml no longer sets android:name, so we inject it here into the <application> tag.
     const manifestFile = path.join(appProjectRoot, 'app', 'src', 'main', 'AndroidManifest.xml');
     replaceTextInFile(manifestFile,
-        'android:name="com.salesforce.androidsdk.phonegap.app.HybridApp"',
-        `android:name="${packageName}.MainApplication"`);
+        'android:manageSpaceActivity="com.salesforce.androidsdk.ui.ManageSpaceActivity"',
+        `android:manageSpaceActivity="com.salesforce.androidsdk.ui.ManageSpaceActivity" android:name="${packageName}.MainApplication"`);
     console.log(`MainApplication.kt injected at ${mainAppDest}`);
 } else {
     console.warn('WARNING: Could not determine package name from config.xml — MainApplication.kt not injected');

--- a/tools/postinstall-android.js
+++ b/tools/postinstall-android.js
@@ -75,8 +75,10 @@ if (data.indexOf("SalesforceHybrid") < 0)
 }
 
 console.log('Injecting MainApplication.kt into generated app');
-const buildGradle = fs.readFileSync(path.join(appProjectRoot, 'app', 'build.gradle'), 'utf8');
-const packageMatch = buildGradle.match(/applicationId\s+["']([^"']+)["']/);
+// Read package name from config.xml (widget id attribute) — more reliable than build.gradle
+// which uses a Gradle variable reference rather than a literal string.
+const configXml = fs.readFileSync('config.xml', 'utf8');
+const packageMatch = configXml.match(/<widget[^>]+\bid=["']([^"']+)["']/);
 if (packageMatch) {
     const packageName = packageMatch[1];
     const packagePath = packageName.replace(/\./g, path.sep);
@@ -94,7 +96,7 @@ if (packageMatch) {
         `android:name="${packageName}.MainApplication"`);
     console.log(`MainApplication.kt injected at ${mainAppDest}`);
 } else {
-    console.warn('WARNING: Could not determine applicationId from app/build.gradle — MainApplication.kt not injected');
+    console.warn('WARNING: Could not determine package name from config.xml — MainApplication.kt not injected');
 }
 
 console.log("Done running SalesforceMobileSDK plugin android post-install script");

--- a/tools/postinstall-android.js
+++ b/tools/postinstall-android.js
@@ -87,7 +87,7 @@ if (packageMatch) {
     const mainAppSrc = path.join(pluginRoot, 'src', 'android', 'MainApplication.kt');
     const mainAppDest = path.join(mainAppSrcDir, 'MainApplication.kt');
     shelljs.cp(mainAppSrc, mainAppDest);
-    replaceTextInFile(mainAppDest, 'com.salesforce.androidsdk.phonegap.app', packageName);
+    replaceTextInFile(mainAppDest, 'package com.salesforce.androidsdk.phonegap.app', `package ${packageName}`);
 
     // Set android:name in AndroidManifest.xml to point to the app's MainApplication.
     // plugin.xml no longer sets android:name, so we inject it here into the <application> tag.

--- a/tools/update.sh
+++ b/tools/update.sh
@@ -158,6 +158,8 @@ copy_android_sdk()
     cp $ANDROID_SDK_FOLDER/gradlew.bat ./
     cp $ANDROID_SDK_FOLDER/gradlew ./
     cp -RL $ANDROID_SDK_FOLDER/gradle ./
+    echo "Copying MainApplication.kt template for postinstall injection"
+    cp $ANDROID_SDK_FOLDER/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/app/MainApplication.kt src/android/MainApplication.kt
 }
 
 parse_opts "$@"


### PR DESCRIPTION
## Summary

Inject `MainApplication.kt` into generated hybrid Android apps via `postinstall-android.js`, mirroring how `postinstall-ios.js` injects `AppDelegate.swift`.

### Changes

- **`tools/update.sh`**: Add explicit copy of `MainApplication.kt` from Android SDK to `src/android/MainApplication.kt` so it is always present at a stable path (dev composite build and GA/Maven Central installs)
- **`src/android/MainApplication.kt`**: Kept in sync with the Android repo version via `update.sh`
- **`postinstall-android.js`**: Reads package name from `config.xml` widget `id`, copies `MainApplication.kt` into the generated app's source tree, replaces only the `package` declaration line (preserving the `import`), sets `android:name` in `AndroidManifest.xml`
- **`plugin.xml`**: Remove `android:name="com.salesforce.androidsdk.phonegap.app.HybridApp"` — `postinstall-android.js` now sets the app's own class

## GUS

W-19408803

## Test plan

- [ ] `test_force.js --cli=forcehybrid --os=android --apptype=hybrid_local` passes
- [ ] Generated `MainApplication.kt` has correct package, correct `import`, correct path
- [ ] `AndroidManifest.xml` has `android:name="<package>.MainApplication"`
- [ ] App launches and authenticates successfully