### PR TITLE
Inject LoginActivity OAuth redirect intent-filter into generated Android apps

### DIFF
--- a/tools/postinstall-android.js
+++ b/tools/postinstall-android.js
@@ -100,4 +100,38 @@ if (packageMatch) {
     console.warn('WARNING: Could not determine package name from config.xml — MainApplication.kt not injected');
 }
 
+// Add the LoginActivity browser-redirect intent-filter with placeholder tokens. forcehybrid
+// substitutes the real callback scheme/host/path via template.js; a direct `cordova plugin add`
+// leaves the placeholders for the developer to fill in. Theme must be @style/SalesforceSDK to
+// match the SalesforceSDK library's LoginActivity or the manifest merger fails. Idempotent.
+console.log('Injecting LoginActivity redirect intent-filter (placeholders) into AndroidManifest.xml');
+const redirectManifestFile = path.join(appProjectRoot, 'app', 'src', 'main', 'AndroidManifest.xml');
+const redirectManifest = fs.readFileSync(redirectManifestFile, 'utf8');
+if (redirectManifest.indexOf('com.salesforce.androidsdk.ui.LoginActivity') === -1) {
+    const loginActivityBlock =
+        '        <!-- Salesforce Mobile SDK OAuth redirect. Replace the __INSERT_..._HERE__ tokens\n' +
+        '             with your callback URL\'s scheme/host/path (forcehybrid does this automatically).\n' +
+        '             Keep android:theme="@style/SalesforceSDK" to match the SDK library. -->\n' +
+        '        <activity\n' +
+        '            android:name="com.salesforce.androidsdk.ui.LoginActivity"\n' +
+        '            android:exported="true"\n' +
+        '            android:launchMode="singleTask"\n' +
+        '            android:theme="@style/SalesforceSDK">\n' +
+        '            <intent-filter>\n' +
+        '                <action android:name="android.intent.action.VIEW" />\n' +
+        '                <category android:name="android.intent.category.DEFAULT" />\n' +
+        '                <category android:name="android.intent.category.BROWSABLE" />\n' +
+        '                <data\n' +
+        '                    android:scheme="__INSERT_CALLBACK_URL_SCHEME_HERE__"\n' +
+        '                    android:host="__INSERT_CALLBACK_URL_HOST_HERE__"\n' +
+        '                    android:path="/__INSERT_CALLBACK_URL_PATH_HERE__" />\n' +
+        '            </intent-filter>\n' +
+        '        </activity>\n';
+    const updatedRedirectManifest = redirectManifest.replace(/([ \t]*)<\/application>/, loginActivityBlock + '$1</application>');
+    fs.writeFileSync(redirectManifestFile, updatedRedirectManifest, 'utf8');
+    console.log('Injected LoginActivity redirect intent-filter with placeholder tokens');
+} else {
+    console.log('LoginActivity already present in manifest — skipping redirect intent-filter injection');
+}
+
 console.log("Done running SalesforceMobileSDK plugin android post-install script");


### PR DESCRIPTION
## What

The Android post-install hook (`tools/postinstall-android.js`) now injects the SDK `LoginActivity` browser-redirect `<intent-filter>` into the generated app's `AndroidManifest.xml`, using `__INSERT_..._HERE__` placeholder tokens for the callback scheme/host/path.

## Why

Browser-based login (Chrome Custom Tabs) is becoming the default in Mobile SDK 14.0. For the OAuth redirect to return to the app, the generated `AndroidManifest.xml` must declare an `<intent-filter>` matching the callback URL. Native and React Native templates ship this filter in their checked-in manifests; hybrid apps had no equivalent because the Cordova manifest is generated at `platform add` time, not checked in.

Because this is a general-purpose plugin, the filter has to work for **both** consumption paths:
- **`forcehybrid` / template generation** — the hybrid `template.js` substitutes the real callback scheme/host/path into the placeholders (see Templates PR #543).
- **standalone `cordova plugin add`** — never runs `template.js`, so the placeholder tokens ship as a self-documenting breadcrumb for the developer to fill in.

## Details

- Injected after the existing `android:name` injection, before `</application>`.
- Idempotent — skips if `com.salesforce.androidsdk.ui.LoginActivity` is already declared.
- `android:theme="@style/SalesforceSDK"` matches the SalesforceSDK library's `LoginActivity`, so the manifest merger reconciles the two declarations by name instead of failing on a theme conflict.
- Placeholder tokens are byte-identical to the `replaceInFiles` search strings in the hybrid templates' `template.js`.

## Testing

- Round-trip verified: hook placeholder block → `template.js` substitution yields zero leftover `__INSERT_…__` tokens for all three callback shapes (hostless `host=""`, host+path, host-only).
- Full real-CLI hybrid generate → `assembleDebug` build proof pending on this split path (gated on this change being present in the plugin the CLI consumes).

Pairs with:
- Templates PR #543 (hybrid `template.js` substitution + native/RN checked-in manifests)
- Package change (parse `--callbackurl` → `config.callbackUrlScheme/Host/Path`)