### PR TITLE
fix(ios): raise pod deployment targets to 15.0 for Xcode 27 compatibility

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -128,6 +128,8 @@
 
     <!-- Post install script -->
     <hook type="after_plugin_install" src="tools/postinstall-ios.js" />
+    <!-- Raise pod deployment targets to 15.0 for Xcode 27 compatibility (after_prepare runs after pod install) -->
+    <hook type="after_prepare" src="tools/postprepare-ios.js" />
   </platform>
 
   <!-- android -->

--- a/tools/postinstall-ios.js
+++ b/tools/postinstall-ios.js
@@ -44,30 +44,4 @@ if (fs.existsSync(bridgingHeaderFile)) {
     console.warn('WARNING: Bridging-Header.h not found at ' + bridgingHeaderFile + ' — InitialViewController will not be visible from Swift. The build will likely fail.');
 }
 
-// Fix Xcode 27 compatibility: raise any pod deployment target below iOS 15.0
-console.log('Patching Podfile to raise minimum pod deployment target to 15.0 for Xcode 27 compatibility');
-const podfilePath = path.join(appProjectRoot, 'Podfile');
-if (fs.existsSync(podfilePath)) {
-    const podfileContents = fs.readFileSync(podfilePath, 'utf8');
-    if (!podfileContents.includes('post_install')) {
-        const postInstallBlock = `
-post_install do |installer|
-  installer.pods_project.targets.each do |target|
-    target.build_configurations.each do |config|
-      dt = config.build_settings['IPHONEOS_DEPLOYMENT_TARGET']
-      if dt && dt.to_f < 15.0
-        config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '15.0'
-      end
-    end
-  end
-end
-`;
-        fs.appendFileSync(podfilePath, postInstallBlock, 'utf8');
-    }
-}
-
 console.log('Done running SalesforceMobileSDK plugin ios post-install script');
-
-
-
-

--- a/tools/postinstall-ios.js
+++ b/tools/postinstall-ios.js
@@ -44,6 +44,28 @@ if (fs.existsSync(bridgingHeaderFile)) {
     console.warn('WARNING: Bridging-Header.h not found at ' + bridgingHeaderFile + ' — InitialViewController will not be visible from Swift. The build will likely fail.');
 }
 
+// Fix Xcode 27 compatibility: raise any pod deployment target below iOS 15.0
+console.log('Patching Podfile to raise minimum pod deployment target to 15.0 for Xcode 27 compatibility');
+const podfilePath = path.join(appProjectRoot, 'Podfile');
+if (fs.existsSync(podfilePath)) {
+    const podfileContents = fs.readFileSync(podfilePath, 'utf8');
+    if (!podfileContents.includes('post_install')) {
+        const postInstallBlock = `
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    target.build_configurations.each do |config|
+      dt = config.build_settings['IPHONEOS_DEPLOYMENT_TARGET']
+      if dt && dt.to_f < 15.0
+        config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '15.0'
+      end
+    end
+  end
+end
+`;
+        fs.appendFileSync(podfilePath, postInstallBlock, 'utf8');
+    }
+}
+
 console.log('Done running SalesforceMobileSDK plugin ios post-install script');
 
 

--- a/tools/postprepare-ios.js
+++ b/tools/postprepare-ios.js
@@ -1,0 +1,27 @@
+console.log('Running SalesforceMobileSDK plugin ios post-prepare script');
+
+const fs = require('fs');
+const path = require('path');
+
+const appProjectRoot = path.join('platforms', 'ios');
+
+// Fix Xcode 27 compatibility: raise any pod deployment target below iOS 15.0.
+// cordova prepare regenerates the Podfile and runs pod install, wiping any
+// post_install block injected earlier. Patch the Pods project directly here
+// instead, after pod install has run.
+const podsProjectFile = path.join(appProjectRoot, 'Pods', 'Pods.xcodeproj', 'project.pbxproj');
+if (fs.existsSync(podsProjectFile)) {
+    console.log('Patching Pods project to raise minimum deployment target to 15.0 for Xcode 27 compatibility');
+    let content = fs.readFileSync(podsProjectFile, 'utf8');
+    const updated = content.replace(/IPHONEOS_DEPLOYMENT_TARGET = (\d+(?:\.\d+)?);/g, (match, version) => {
+        return parseFloat(version) < 15.0
+            ? 'IPHONEOS_DEPLOYMENT_TARGET = 15.0;'
+            : match;
+    });
+    if (updated !== content) {
+        fs.writeFileSync(podsProjectFile, updated, 'utf8');
+        console.log('Done patching Pods project deployment targets');
+    }
+}
+
+console.log('Done running SalesforceMobileSDK plugin ios post-prepare script');


### PR DESCRIPTION
## Summary

- Xcode 27 requires all pod deployment targets to be >= 15.0, but Hybrid templates use a Cordova-generated `Podfile` that does not include the `mobile_sdk_post_install` hook that native iOS templates rely on
- Third-party Cordova pods (Cordova: 13.0, SQLCipher: 12.0, FMDB: 12.0) remain below 15.0 and fail at build time with: _"the range of supported deployment target versions is 15.0 to 27.0.x"_
- `tools/postinstall-ios.js` now injects a `post_install` block into `platforms/ios/Podfile` that raises any pod deployment target below 15.0 to 15.0; the injection is guarded so it is skipped if a `post_install` block is already present

GUS: W-24057371

## Test plan

- [ ] Generate a HybridLocalTemplate or HybridRemoteTemplate app using the CordovaPlugin from this branch
- [ ] Run `cordova build ios` on Xcode 27 — confirm no "deployment target" errors from Cordova/SQLCipher/FMDB pods
- [ ] Confirm `platforms/ios/Podfile` contains the injected `post_install` block after `cordova plugin add`
- [ ] Run on Xcode < 27 to confirm no regression (targets already >= 15.0, block skips the assignment)